### PR TITLE
feat: Implemented Puppeteer to V8 Class

### DIFF
--- a/lib/puppeteer-to-v8.js
+++ b/lib/puppeteer-to-v8.js
@@ -1,5 +1,11 @@
-module.exports = class PuppeteerToV8 {
+class PuppeteerToV8 {
   constructor (coverageInfo) {
     this.coverageInfo = coverageInfo
   }
+
+  convertCoverage () {
+    return this.coverageInfo
+  }
 }
+
+module.exports = () => new PuppeteerToV8()

--- a/lib/puppeteer-to-v8.js
+++ b/lib/puppeteer-to-v8.js
@@ -3,8 +3,21 @@ class PuppeteerToV8 {
     this.coverageInfo = coverageInfo
   }
 
+  setCoverageInfo (coverageInfo) {
+    this.coverageInfo = coverageInfo
+  }
+
   convertCoverage () {
-    return this.coverageInfo
+    // Iterate through coverage info and create IDs
+    let id = 0
+
+    return this.coverageInfo.map(coverageItem => {
+      return {
+        scriptId: id++,
+        url: coverageItem.url,
+        functions: { ranges: coverageItem.ranges }
+      }
+    })
   }
 }
 

--- a/lib/puppeteer-to-v8.js
+++ b/lib/puppeteer-to-v8.js
@@ -1,7 +1,5 @@
-class PuppeteerToV8 {
-  // constructor () {}
-}
-
-module.exports = () => {
-  return new PuppeteerToV8()
+module.exports = class PuppeteerToV8 {
+  constructor (coverageInfo) {
+    this.coverageInfo = coverageInfo
+  }
 }

--- a/test/puppeteer-to-v8.js
+++ b/test/puppeteer-to-v8.js
@@ -8,8 +8,12 @@ describe('puppeteer-to-v8', () => {
   it('translates ranges into v8 format', () => {
     const fixture = require('./fixtures/function-coverage-missing')
 
-    let v8Coverage = PuppeteerToV8.convertCoverage(fixture)
-    console.log(v8Coverage)
+    PuppeteerToV8.setCoverageInfo(fixture)
+
+    let v8Coverage = PuppeteerToV8.convertCoverage()
+
+    // V8 coverage has ranges on a functions object, so check for that
+    v8Coverage[0].functions.ranges.should.eql(fixture[0].ranges)
   })
 
   // use mkdirp:

--- a/test/puppeteer-to-v8.js
+++ b/test/puppeteer-to-v8.js
@@ -1,12 +1,12 @@
-/* globals describe, it */
+/* globals describe, it, before */
 
 var PuppeteerToV8 = require('../lib/puppeteer-to-v8')()
 
 require('chai').should()
 
 describe('puppeteer-to-v8', () => {
-  let v8Coverage;
-  const fixture = require('./fixtures/function-coverage-missing');
+  let v8Coverage
+  const fixture = require('./fixtures/function-coverage-missing')
 
   before(() => {
     PuppeteerToV8.setCoverageInfo(fixture)

--- a/test/puppeteer-to-v8.js
+++ b/test/puppeteer-to-v8.js
@@ -5,13 +5,16 @@ var PuppeteerToV8 = require('../lib/puppeteer-to-v8')()
 require('chai').should()
 
 describe('puppeteer-to-v8', () => {
-  it('translates ranges into v8 format', () => {
-    const fixture = require('./fixtures/function-coverage-missing')
+  let v8Coverage;
+  const fixture = require('./fixtures/function-coverage-missing');
 
+  before(() => {
     PuppeteerToV8.setCoverageInfo(fixture)
 
-    let v8Coverage = PuppeteerToV8.convertCoverage()
+    v8Coverage = PuppeteerToV8.convertCoverage()
+  })
 
+  it('translates ranges into v8 format', () => {
     // V8 coverage has ranges on a functions object, so check for that
     v8Coverage[0].functions.ranges.should.eql(fixture[0].ranges)
   })
@@ -24,8 +27,9 @@ describe('puppeteer-to-v8', () => {
 
   // look at the uuid library:
   // uuid.v4()
-  it('generates scriptID', () => {
-
+  it('generates scriptId', () => {
+    // Ensures that the scriptId is of type 'number'
+    (typeof v8Coverage[0].scriptId).should.eql('number')
   })
 
   // for this test case, make sure we cover what happens

--- a/test/puppeteer-to-v8.js
+++ b/test/puppeteer-to-v8.js
@@ -1,12 +1,15 @@
 /* globals describe, it */
 
-const puppeteerToV8 = require('../lib/puppeteer-to-v8')()
+var PuppeteerToV8 = require('../lib/puppeteer-to-v8')
 
 require('chai').should()
 
 describe('puppeteer-to-v8', () => {
   it('translates ranges into v8 format', () => {
-    console.info(puppeteerToV8)
+    const fixture = require('./fixtures/function-coverage-missing')
+
+    let v8Coverage = new PuppeteerToV8(fixture)
+    console.log(v8Coverage)
   })
 
   // use mkdirp:

--- a/test/puppeteer-to-v8.js
+++ b/test/puppeteer-to-v8.js
@@ -1,6 +1,6 @@
 /* globals describe, it */
 
-var PuppeteerToV8 = require('../lib/puppeteer-to-v8')
+var PuppeteerToV8 = require('../lib/puppeteer-to-v8')()
 
 require('chai').should()
 
@@ -8,7 +8,7 @@ describe('puppeteer-to-v8', () => {
   it('translates ranges into v8 format', () => {
     const fixture = require('./fixtures/function-coverage-missing')
 
-    let v8Coverage = new PuppeteerToV8(fixture)
+    let v8Coverage = PuppeteerToV8.convertCoverage(fixture)
     console.log(v8Coverage)
   })
 


### PR DESCRIPTION
Implemented the `PuppeteerToV8` class with a setter function for setting the `coverageInfo`, and a `convertCoverage` function that uses a `map` function to go through and convert from the Puppeteer to V8 format. Also implemented the tests that are handled by `PuppeteerToV8` without the need of `OutputFiles` (which will handle file renaming and inline JS naming).