### PR TITLE
chore: Fixed README coverage link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Convert coverage from the format outputted by [puppeteer](https://developers.goo
 
 ## Usage
 
-### to output coverage in Istanbul format with puppeteer
+### To Output Coverage in Istanbul Format with Puppeteer
 
 1. install _puppeteer-to-istanbul_, `npm i puppeteer-to-istanbul`.
 2. run your code in puppeteer with coverage enabled:
@@ -32,7 +32,7 @@ Convert coverage from the format outputted by [puppeteer](https://developers.goo
     pti.write(jsCoverage)
     ```
         
-### to run istanbul reports
+### To Run Istanbul Reports
 
 1. install nyc, `npm i nyc -g`.
 2. use nyc's report functionality:
@@ -54,9 +54,9 @@ To learn about the conversion process between Puppeteer to Istanbul, and everyth
 
 If you see an issue with Puppeteer to Istanbul, please open an issue! If you want to help improve Puppeteer to Istanbul, please fork the repository and open a pull request with your changes.
 
-Make sure to review our [contributing guide][contributing]
+Make sure to review our [contributing guide][contributing] for specific guidelines on contributing.
 
 [coveralls]: https://github.com/GoogleChrome/puppeteer
 [istanbul]: https://github.com/istanbuljs/istanbuljs
 [nyc]: https://github.com/istanbuljs/nyc
-[contributing]: CONTRIBUTING.md
+[contributing]: https://github.com/istanbuljs/puppeteer-to-istanbul/blob/master/CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -46,10 +46,6 @@ consumed by nyc.
 
 see [istanbul](https://github.com/istanbuljs/istanbuljs/tree/master/packages/istanbul-reports/lib) for a list of possible reporters.
 
-## Project Website
-
-To learn about the conversion process between Puppeteer to Istanbul, and everything in between, visit the project's [website](https://hack-illinois-team-istanbul.herokuapp.com/).
-
 ## Contributing
 
 If you see an issue with Puppeteer to Istanbul, please open an issue! If you want to help improve Puppeteer to Istanbul, please fork the repository and open a pull request with your changes.


### PR DESCRIPTION
Updated README to fix titles not being title-case and to fix the CONTRIBUTING link being broken on the NPM site due to it not being absolute.

I was also considering removing the splash page link, since that site has not been updated yet and does not provide any information that is not in the README. What are your thoughts on this?