### PR TITLE
Use current time in output file name

### DIFF
--- a/lib/puppeteer-to-istanbul.js
+++ b/lib/puppeteer-to-istanbul.js
@@ -29,7 +29,7 @@ class PuppeteerToIstanbul {
     })
 
     mkdirp.sync('./.nyc_output')
-    fs.writeFileSync('./.nyc_output/out.json', JSON.stringify(fullJson), 'utf8')
+    fs.writeFileSync(`./.nyc_output/out-${Date.now()}.json`, JSON.stringify(fullJson), 'utf8')
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/istanbuljs/puppeteer-to-istanbul/issues/20

### Pros
- One test run can have multiple coverage reports

### Cons
- Need to delete `.nyc_output` folder before running the test suite

### Alternative
If https://github.com/istanbuljs/puppeteer-to-istanbul/pull/25 is merged, Users can define different fileNames as required.