### PR TITLE
Add options to change outputFile and filter coverage files

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,17 @@ Convert coverage from the format outputted by [puppeteer](https://developers.goo
         page.coverage.stopJSCoverage(),
         page.coverage.stopCSSCoverage(),
       ]);
-      pti.write(jsCoverage)
+      pti.write(jsCoverage /* , options */)
       await browser.close()
     })()
     ```
+
+#### options
+
+| option     | Description                                                                                                      | Default Value            |
+| :--------- | :--------------------------------------------------------------------------------------------------------------- | :----------------------- |
+| outputFile | Output coverage will be saved at this file path (can be relative to project root dir or an absolute path)        | `./.nyc_output/out.json` |
+| filter     | Function to filter coverage files. Coverage will only be saved if it returns `true` for give filePath | `(filePath) => true`     |
 
 ### To Run Istanbul Reports
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 const PuppeteerToIstanbul = require('./lib/puppeteer-to-istanbul')
 
 module.exports = {
-  write: (puppeteerFormat) => {
+  write: (puppeteerFormat, options) => {
     const pti = PuppeteerToIstanbul(puppeteerFormat)
-    pti.writeIstanbulFormat()
+    return pti.writeIstanbulFormat(options)
   }
 }

--- a/lib/puppeteer-to-istanbul.js
+++ b/lib/puppeteer-to-istanbul.js
@@ -6,7 +6,7 @@ const v8toIstanbul = require('v8-to-istanbul')
 
 class PuppeteerToIstanbul {
   constructor (coverageInfo) {
-    this.coverageInfo = coverageInfo
+    this.setCoverageInfo(coverageInfo)
     this.puppeteerToConverter = OutputFiles(coverageInfo).getTransformedCoverage()
     this.puppeteerToV8Info = PuppeteerToV8(this.puppeteerToConverter).convertCoverage()
   }
@@ -15,10 +15,12 @@ class PuppeteerToIstanbul {
     this.coverageInfo = coverageInfo
   }
 
-  writeIstanbulFormat () {
+  writeIstanbulFormat ({ outputFile = './.nyc_output/out.json', filter = () => true } = {}) {
     var fullJson = {}
 
     this.puppeteerToV8Info.forEach(jsFile => {
+      if (!filter(jsFile.url)) return
+
       const script = v8toIstanbul(jsFile.url)
       script.applyCoverage(jsFile.functions)
 
@@ -28,8 +30,11 @@ class PuppeteerToIstanbul {
       fullJson[keys[0]] = istanbulCoverage[keys[0]]
     })
 
-    mkdirp.sync('./.nyc_output')
-    fs.writeFileSync('./.nyc_output/out.json', JSON.stringify(fullJson), 'utf8')
+    const dirName = outputFile.split('/').splice(-1, 1).join('/')
+    mkdirp.sync(dirName)
+    fs.writeFileSync(outputFile, JSON.stringify(fullJson), 'utf8')
+
+    return outputFile
   }
 }
 

--- a/test/fixtures/multiple-files.json
+++ b/test/fixtures/multiple-files.json
@@ -1,0 +1,44 @@
+[
+  {
+    "url": "http://localhost:9000/js/index.js",
+    "ranges": [{
+      "start": 0,
+      "end": 277
+    }],
+    "text": "import docReady from \"./utils/doc_ready.js\";\nimport Record from \"./models/record.js\";\nimport RecordView from \"./views/record.js\";\n\ndocReady(() => {\n  let record = new Record(3, 4);\n  let recordView = new RecordView(record);\n  document.body.appendChild(recordView.render())\n});\n"
+  },
+  {
+    "url": "http://localhost/js/utils/doc_ready.js",
+    "ranges": [{
+        "start": 0,
+        "end": 80
+      },
+      {
+        "start": 146,
+        "end": 150
+      }
+    ],
+    "text": "export default (fn) => {\n  if (document.readyState != \"loading\") {\n    fn();\n  } else {\n    document.addEventListener(\"DOMContentLoaded\", fn);\n  }\n};\n"
+  },
+  {
+    "url": "http://localhost:9000/js/models/record.js",
+    "ranges": [{
+      "start": 0,
+      "end": 90
+    }],
+    "text": "export default class Record {\n  constructor(x, y) {\n    this.x = x;\n    this.y = y;\n  }\n}\n"
+  },
+  {
+    "url": "http://localhost:9000/js/views/record.js",
+    "ranges": [{
+        "start": 0,
+        "end": 298
+      },
+      {
+        "start": 301,
+        "end": 304
+      }
+    ],
+    "text": "export default class RecordView {\n  constructor(record) {\n    this.record = record\n  }\n\n  render() {\n    this.elem = document.createElement(\"div\");\n    this.elem.appendChild(\n      document.createTextNode(\n        \"x: \" + this.record.x + \"; y: \" + this.record.y\n      )\n    );\n    return this.elem;\n  }\n}"
+  }
+]

--- a/test/puppeteer-to-istanbul.js
+++ b/test/puppeteer-to-istanbul.js
@@ -1,19 +1,55 @@
-// /* globals describe, it, before */
+/* globals describe, it */
 
-// var PuppeteerToIstanbul = require('../lib/puppeteer-to-istanbul')()
+const fs = require('fs')
 
-// require('chai').should()
+const PuppeteerToIstanbul = require('../lib/puppeteer-to-istanbul')
 
-// describe('puppeteer-to-istanbul', () => {
+require('chai').should()
 
-//   const fixture = require('./fixtures/function-coverage-missing.json')
+describe('puppeteer-to-istanbul', () => {
+  const fixture = require('./fixtures/multiple-files.json')
 
-//   before(() => {
+  it('writes coverage to default filePath', () => {
+    const filePath = new PuppeteerToIstanbul(fixture).writeIstanbulFormat()
 
-//   })
+    filePath.should.eq('./.nyc_output/out.json')
+    fs.existsSync(filePath).should.eq(true)
 
-//   it('translates ranges into lines for istanbul', () => {
+    fs.unlinkSync(filePath)
+  })
 
-//   })
+  it('writes coverage to given filePath', () => {
+    const filePath = new PuppeteerToIstanbul(fixture).writeIstanbulFormat({ outputFile: './.nyc_output/custom.json' })
 
-// })
+    filePath.should.eq('./.nyc_output/custom.json')
+    fs.existsSync(filePath).should.eq(true)
+
+    fs.unlinkSync(filePath)
+  })
+
+  it("doesn't filter any files by default", () => {
+    const filePath = new PuppeteerToIstanbul(fixture).writeIstanbulFormat()
+
+    filePath.should.eq('./.nyc_output/out.json')
+
+    const savedJson = JSON.parse(fs.readFileSync(filePath))
+
+    Object.keys(savedJson).length.should.eq(4)
+
+    fs.unlinkSync(filePath)
+  })
+
+  it('applies filter when given', () => {
+    const filePath = new PuppeteerToIstanbul(fixture).writeIstanbulFormat({
+      filter: (jsFile) => jsFile.indexOf('record') === -1
+    })
+
+    filePath.should.eq('./.nyc_output/out.json')
+
+    const savedJson = JSON.parse(fs.readFileSync(filePath))
+
+    Object.keys(savedJson).length.should.eq(2)
+
+    fs.unlinkSync(filePath)
+  })
+})

--- a/test/puppeteer-to-istanbul.js
+++ b/test/puppeteer-to-istanbul.js
@@ -29,9 +29,6 @@ describe('puppeteer-to-istanbul', () => {
 
   it("doesn't filter any files by default", () => {
     const filePath = new PuppeteerToIstanbul(fixture).writeIstanbulFormat()
-
-    filePath.should.eq('./.nyc_output/out.json')
-
     const savedJson = JSON.parse(fs.readFileSync(filePath))
 
     Object.keys(savedJson).length.should.eq(4)
@@ -43,9 +40,6 @@ describe('puppeteer-to-istanbul', () => {
     const filePath = new PuppeteerToIstanbul(fixture).writeIstanbulFormat({
       filter: (jsFile) => jsFile.indexOf('record') === -1
     })
-
-    filePath.should.eq('./.nyc_output/out.json')
-
     const savedJson = JSON.parse(fs.readFileSync(filePath))
 
     Object.keys(savedJson).length.should.eq(2)


### PR DESCRIPTION
closes https://github.com/istanbuljs/puppeteer-to-istanbul/issues/15

Adds two options to `PuppeteerToIstanbul.prototype.writeIstanbulFormat`

__Note:__ This doesn't change default behaviour

### Usage

`pti.write(coverage, options)`

### Options

| option     | Description                                                                                                      | Default Value            |
| :--------- | :--------------------------------------------------------------------------------------------------------------- | :----------------------- |
| outputFile | Output coverage will be saved at this file path (can be relative to project root dir or an absolute path)        | `./.nyc_output/out.json` |
| filter     | Function to filter coverage files. Coverage will only be saved if it returns `true` for given filePath | `(filePath) => true`     |

### Additional changes

Added tests for `lib/puppeteer-to-istanbul.js` with 100% coverage 🚀 