### PR TITLE
docs: Update README for outputting both js coverage and css coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Convert coverage from the format outputted by [puppeteer](https://developers.goo
         page.coverage.stopJSCoverage(),
         page.coverage.stopCSSCoverage(),
       ]);
-      pti.write(jsCoverage)
+      pti.write([...jsCoverage, ...cssCoverage])
       await browser.close()
     })()
     ```


### PR DESCRIPTION
The example code in README doesn’t use `cssCoverage`. But `ptoi.write` can output both js coverage and css coverage if concatting coverages. I think adding that thing to the example code is kind.