### PR TITLE
fix: remove illegal chars from generated filenames

### DIFF
--- a/lib/output-files.js
+++ b/lib/output-files.js
@@ -50,6 +50,9 @@ class OutputFiles {
     let str = ``
     let parsedPath = this.parsePath(path)
 
+    // Remove illegal chars from filename
+    parsedPath = parsedPath.replace(/[/\\?%*:|"<>]/g, '_')
+    
     // Special case: when html present, strip and return specialized string
     if (parsedPath.includes('.html')) {
       parsedPath = pathLib.resolve(storagePath, parsedPath) + 'puppeteerTemp-inline'


### PR DESCRIPTION
Removes characters from URL-derived filenames that are not valid characters

ref #33 