### PR TITLE
chore(deps): bump v8-to-istanbul from 1.2.1 to 4.1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "8"
+  - "10"
   - "node"
 after_success:
   - c8 report --reporter=text-lcov | coveralls

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Convert coverage from the format outputted by [puppeteer](https://developers.goo
         page.coverage.stopJSCoverage(),
         page.coverage.stopCSSCoverage(),
       ]);
-      pti.write([...jsCoverage, ...cssCoverage], { includeHostname: true , storagePath: './.nyc_output' })
+      await pti.write([...jsCoverage, ...cssCoverage], { includeHostname: true , storagePath: './.nyc_output' })
       await browser.close()
     })()
     ```

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 const PuppeteerToIstanbul = require('./lib/puppeteer-to-istanbul')
 
 module.exports = {
-  write: (puppeteerFormat, options) => {
+  write: async (puppeteerFormat, options) => {
     const pti = PuppeteerToIstanbul(puppeteerFormat, options)
-    pti.writeIstanbulFormat(options)
+    await pti.writeIstanbulFormat(options)
   }
 }

--- a/lib/puppeteer-to-istanbul.js
+++ b/lib/puppeteer-to-istanbul.js
@@ -21,7 +21,7 @@ class PuppeteerToIstanbul {
     this.coverageInfo = coverageInfo
   }
 
-  writeIstanbulFormat () {
+  async writeIstanbulFormat () {
     mkdirp.sync(this.storagePath)
 
     const outFilePath = `${this.storagePath}/out.json`
@@ -30,10 +30,16 @@ class PuppeteerToIstanbul {
 
     const fd = fs.openSync(outFilePath, 'a')
 
-    this.puppeteerToV8Info.forEach((jsFile, index) => {
+    for (const jsFile of this.puppeteerToV8Info) {
+      // the path to the original source-file is required, as its contents are
+      // used during the conversion algorithm.
       const script = v8toIstanbul(jsFile.url)
+
+      // this is required due to the async source-map dependency
+      await script.load()
       script.applyCoverage(jsFile.functions)
 
+      // output coverage information in a form that can be consumed by Istanbul.
       let istanbulCoverage = script.toIstanbul()
       let keys = Object.keys(istanbulCoverage)
 
@@ -44,7 +50,7 @@ class PuppeteerToIstanbul {
         jsonPart[keys[0]] = istanbulCoverage[keys[0]]
       }
       jsonPart[keys[0]].originalUrl = jsFile.originalUrl
-    })
+    }
 
     fs.writeSync(fd, '{')
     Object.keys(jsonPart).forEach((url, index, keys) => {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "clone": "^2.1.2",
     "mkdirp": "^1.0.4",
-    "v8-to-istanbul": "^1.2.1",
+    "v8-to-istanbul": "^4.1.4",
     "yargs": "^15.3.1"
   },
   "standard": {

--- a/test/puppeteer-to-istanbul.js
+++ b/test/puppeteer-to-istanbul.js
@@ -7,20 +7,20 @@ const OutputFiles = require('../lib/output-files')
 var PuppeteerToIstanbul = require('../lib/puppeteer-to-istanbul')
 
 describe('puppeteer-to-istanbul', () => {
-  it('outputs a valid out.json file, to the default location', () => {
+  it('outputs a valid out.json file, to the default location', async () => {
     const fixture = require('./fixtures/two-inline.json')
     const pti = PuppeteerToIstanbul(fixture)
-    pti.writeIstanbulFormat()
+    await pti.writeIstanbulFormat()
     const content = fs.readFileSync('.nyc_output/out.json', 'utf8')
     const jsonObject = JSON.parse(content)
     should.exist(jsonObject)
     fs.unlinkSync('.nyc_output/out.json')
   })
 
-  it('outputs a valid out.json file, in the custom location', () => {
+  it('outputs a valid out.json file, in the custom location', async () => {
     const fixture = require('./fixtures/two-inline.json')
     const pti = PuppeteerToIstanbul(fixture, { storagePath: '.nyc_output/custom' })
-    pti.writeIstanbulFormat()
+    await pti.writeIstanbulFormat()
     const content = fs.readFileSync('.nyc_output/custom/out.json', 'utf8')
     const jsonObject = JSON.parse(content)
     should.exist(jsonObject)
@@ -34,24 +34,24 @@ describe('puppeteer-to-istanbul', () => {
     pti.coverageInfo.should.eql(fixture)
   })
 
-  it('merge non-inline script coverage records', () => {
+  it('merge non-inline script coverage records', async () => {
     OutputFiles.resetIterator()
     PuppeteerToIstanbul.resetJSONPart()
 
     const fixtureNonInlineScriptA = require('./fixtures/merge-coverage/non-inline-script-a.json')
     const fixtureNonInlineScriptB = require('./fixtures/merge-coverage/non-inline-script-b.json')
     const ptiA = PuppeteerToIstanbul(fixtureNonInlineScriptA)
-    ptiA.writeIstanbulFormat()
+    await ptiA.writeIstanbulFormat()
     const jsonPartA = PuppeteerToIstanbul.getJSONPart()
     PuppeteerToIstanbul.resetJSONPart()
     const ptiB = PuppeteerToIstanbul(fixtureNonInlineScriptB)
-    ptiB.writeIstanbulFormat()
+    await ptiB.writeIstanbulFormat()
     const jsonPartB = PuppeteerToIstanbul.getJSONPart()
     PuppeteerToIstanbul.resetJSONPart()
     OutputFiles.resetIterator()
     PuppeteerToIstanbul.resetJSONPart()
     const pti = PuppeteerToIstanbul(fixtureNonInlineScriptA.concat(fixtureNonInlineScriptB))
-    pti.writeIstanbulFormat()
+    await pti.writeIstanbulFormat()
     const jsonPart = PuppeteerToIstanbul.getJSONPart()
     const keys = Object.keys(jsonPart)
 


### PR DESCRIPTION
Note that this is breaking due to the required `load` method of the async source-map dependency. Changing the public interface of write to async has its advantages of later upgrading/updating the file system parts to async/promises.

Updated Travis to use the maintenance LTS (node 10 which will be EOL 2021-04-30), see https://nodejs.org/en/about/releases/ for more info.

Fixes #49 