### PR TITLE
feat: allow path renaming

### DIFF
--- a/lib/output-files.js
+++ b/lib/output-files.js
@@ -14,6 +14,7 @@ let iterator = {}
 class OutputFiles {
   constructor (coverageInfo, options = {}) {
     this.storagePath = options.storagePath || './.nyc_output/js'
+    this.filePathTransformer = options.transformPath || ((filePath) => filePath)
     this.includeHostname = options.hasOwnProperty('includeHostname') ? options.includeHostname : true
 
     // Clone coverageInfo to prevent mutating the passed in data

--- a/lib/puppeteer-to-istanbul.js
+++ b/lib/puppeteer-to-istanbul.js
@@ -9,6 +9,7 @@ let jsonPart = {}
 class PuppeteerToIstanbul {
   constructor (coverageInfo, options = {}) {
     this.storagePath = options.storagePath || './.nyc_output'
+    this.filePathTransformer = options.transformPath || ((filePath) => filePath)
     this.includeHostname = options.hasOwnProperty('includeHostname') ? options.includeHostname : true
 
     this.coverageInfo = coverageInfo
@@ -37,13 +38,17 @@ class PuppeteerToIstanbul {
       let istanbulCoverage = script.toIstanbul()
       let keys = Object.keys(istanbulCoverage)
 
-      if (jsonPart[keys[0]]) {
+      const istanbulKey = keys[0]
+      const filePath = this.filePathTransformer(istanbulKey)
+
+      if (jsonPart[filePath]) {
         // Merge coverage records
-        mergeCoverageData(jsonPart[keys[0]].s, istanbulCoverage[keys[0]].s)
+        mergeCoverageData(jsonPart[filePath].s, istanbulCoverage[istanbulKey].s)
       } else {
-        jsonPart[keys[0]] = istanbulCoverage[keys[0]]
+        jsonPart[filePath] = istanbulCoverage[istanbulKey]
       }
-      jsonPart[keys[0]].originalUrl = jsFile.originalUrl
+      jsonPart[filePath].originalUrl = jsFile.originalUrl
+      jsonPart[filePath].path = filePath
     })
 
     fs.writeSync(fd, '{')

--- a/test/puppeteer-to-istanbul.js
+++ b/test/puppeteer-to-istanbul.js
@@ -27,6 +27,37 @@ describe('puppeteer-to-istanbul', () => {
     fs.unlinkSync('.nyc_output/custom/out.json')
   })
 
+  it('outputs a valid out.json file, with a custom path name', async () => {
+    const fixture = require('./fixtures/two-inline.json')
+
+    const ptiA = PuppeteerToIstanbul(fixture)
+    ptiA.writeIstanbulFormat()
+    const contentA = fs.readFileSync('.nyc_output/out.json', 'utf8')
+    const jsonObjectA = JSON.parse(contentA)
+    should.exist(jsonObjectA)
+    const keysA = Object.keys(jsonObjectA)
+    let firstKeyA = keysA[0]
+    if (firstKeyA.includes('\\')) firstKeyA = firstKeyA.replace(/\\/g, '/')
+    firstKeyA.should.include('.nyc_output/js/tmp/puppeteerTemp.htmlpuppeteerTemp-inline.js')
+    keysA[0].should.equal(jsonObjectA[keysA[0]].path)
+    fs.unlinkSync('.nyc_output/out.json')
+
+    PuppeteerToIstanbul.resetJSONPart()
+    OutputFiles.resetIterator()
+
+    const ptiB = PuppeteerToIstanbul(fixture, { transformPath: (path) => path.replace('.nyc_output', '.nyc_input') })
+    ptiB.writeIstanbulFormat()
+    const contentB = fs.readFileSync('.nyc_output/out.json', 'utf8')
+    const jsonObjectB = JSON.parse(contentB)
+    should.exist(jsonObjectB)
+    const keysB = Object.keys(jsonObjectB)
+    let firstKeyB = keysB[0]
+    if (firstKeyB.includes('\\')) firstKeyB = firstKeyB.replace(/\\/g, '/')
+    firstKeyB.should.include('.nyc_input/js/tmp/puppeteerTemp.htmlpuppeteerTemp-inline-1.js')
+    keysB[0].should.equal(jsonObjectB[keysB[0]].path)
+    fs.unlinkSync('.nyc_output/out.json')
+  })
+
   it('correctly sets coverage info', () => {
     const fixture = require('./fixtures/two-inline.json')
     const pti = PuppeteerToIstanbul(fixture)


### PR DESCRIPTION
This can allow users to remove the `.nyc_output` from the filePath, that way coverage tools such as Codecov can actually report coverage.