### PR TITLE
fix: map paths back to original file paths

### DIFF
--- a/lib/output-files.js
+++ b/lib/output-files.js
@@ -13,7 +13,7 @@ let iterator = {}
 
 class OutputFiles {
   constructor (coverageInfo, options = {}) {
-    this.storagePath = options.storagePath || './.nyc_output/js'
+    this.storagePath = pathLib.resolve(options.storagePath, 'js')
     this.includeHostname = options.hasOwnProperty('includeHostname') ? options.includeHostname : true
 
     // Clone coverageInfo to prevent mutating the passed in data
@@ -77,6 +77,19 @@ class OutputFiles {
   _parseAndIsolate () {
     for (let i = 0; i < this.coverageInfo.length; i++) {
       let path = this.rewritePath(this.coverageInfo[i].url)
+      this.coverageInfo[i].realPath = pathLib.resolve(pathLib.resolve(this.storagePath, '..', '..'), pathLib.relative(this.storagePath, path))
+      const sourceMappingUrlMatch = this.coverageInfo[i].text.match(/^\/\/# sourceMappingURL=data:application\/json;charset=utf-8;base64,(.*)$/m)
+      if (sourceMappingUrlMatch !== null) {
+        const sourceMapping = JSON.parse(Buffer.from(sourceMappingUrlMatch[1], 'base64').toString('utf-8'))
+        this.coverageInfo[i].sourceMapping = {
+          version: sourceMapping.version,
+          file: this.coverageInfo[i].realPath,
+          sources: [pathLib.basename(this.coverageInfo[i].realPath)],
+          sourceRoot: pathLib.dirname(this.coverageInfo[i].realPath),
+          mappings: sourceMapping.mappings,
+          sourcesContent: sourceMapping.sourcesContent,
+        }
+      }
 
       this.coverageInfo[i].originalUrl = this.coverageInfo[i].url
       this.coverageInfo[i].url = path

--- a/lib/output-files.js
+++ b/lib/output-files.js
@@ -45,12 +45,11 @@ class OutputFiles {
     return postProtocolPath
   }
 
-  rewritePath (path) {
+  rewritePath (parsedPath) {
     // generate a new path relative to ./coverage/js.
     // this would be around where you'd use mkdirp.
 
     let str = ``
-    let parsedPath = this.parsePath(path)
     let isInline = false
     // Special case: when html present, strip and return specialized string
     if (pathLib.extname(parsedPath) === '.html') {
@@ -76,28 +75,30 @@ class OutputFiles {
 
   _parseAndIsolate () {
     for (let i = 0; i < this.coverageInfo.length; i++) {
-      let path = this.rewritePath(this.coverageInfo[i].url)
-      this.coverageInfo[i].realPath = pathLib.resolve(this.parsePath(this.coverageInfo[i].url))
+      const parsedPath = this.parsePath(this.coverageInfo[i].url)
+      const rewrittenPath = this.rewritePath(parsedPath)
       const sourceMappingUrlMatch = this.coverageInfo[i].text.match(/^\/\/# sourceMappingURL=data:application\/json;charset=utf-8;base64,(.*)$/m)
+      const sourceMapping = sourceMappingUrlMatch !== null
+        ? JSON.parse(Buffer.from(sourceMappingUrlMatch[1], 'base64').toString('utf-8'))
+        : {}
+        
+      this.coverageInfo[i].realPath = pathLib.resolve(sourceMapping.sourceRoot || '.', parsedPath)
 
-      if (sourceMappingUrlMatch !== null) {
-        const sourceMapping = JSON.parse(Buffer.from(sourceMappingUrlMatch[1], 'base64').toString('utf-8'))
+      if (Object.keys(sourceMapping).length > 0) {
         this.coverageInfo[i].sourceMapping = {
-          version: sourceMapping.version,
+          ...sourceMapping,
           file: this.coverageInfo[i].realPath,
-          sources: [pathLib.basename(this.coverageInfo[i].realPath)],
-          sourceRoot: pathLib.dirname(this.coverageInfo[i].realPath),
-          mappings: sourceMapping.mappings,
-          sourcesContent: sourceMapping.sourcesContent,
+          sources: sourceMapping.sources.map(source => this.parsePath(source)),
+          sourceRoot: sourceMapping.sourceRoot || process.cwd(),
         }
       }
 
       this.coverageInfo[i].originalUrl = this.coverageInfo[i].url
-      this.coverageInfo[i].url = path
+      this.coverageInfo[i].url = rewrittenPath
 
-      mkdirp.sync(pathLib.parse(path).dir)
+      mkdirp.sync(pathLib.parse(rewrittenPath).dir)
 
-      fs.writeFileSync(path, this.coverageInfo[i].text)
+      fs.writeFileSync(rewrittenPath, this.coverageInfo[i].text)
     }
   }
 

--- a/lib/output-files.js
+++ b/lib/output-files.js
@@ -25,10 +25,10 @@ class OutputFiles {
     let urlPath
 
     try {
-      urlPath = new url.URL(path)
+      urlPath = new url.parse(path)
     } catch (error) {
       path = 'file://' + path
-      urlPath = new url.URL(path)
+      urlPath = new url.parse(path)
     }
 
     let postProtocolPath = urlPath.pathname.substring(1)

--- a/lib/output-files.js
+++ b/lib/output-files.js
@@ -77,8 +77,9 @@ class OutputFiles {
   _parseAndIsolate () {
     for (let i = 0; i < this.coverageInfo.length; i++) {
       let path = this.rewritePath(this.coverageInfo[i].url)
-      this.coverageInfo[i].realPath = pathLib.resolve(pathLib.resolve(this.storagePath, '..', '..'), pathLib.relative(this.storagePath, path))
+      this.coverageInfo[i].realPath = pathLib.resolve(this.parsePath(this.coverageInfo[i].url))
       const sourceMappingUrlMatch = this.coverageInfo[i].text.match(/^\/\/# sourceMappingURL=data:application\/json;charset=utf-8;base64,(.*)$/m)
+
       if (sourceMappingUrlMatch !== null) {
         const sourceMapping = JSON.parse(Buffer.from(sourceMappingUrlMatch[1], 'base64').toString('utf-8'))
         this.coverageInfo[i].sourceMapping = {

--- a/lib/puppeteer-to-istanbul.js
+++ b/lib/puppeteer-to-istanbul.js
@@ -1,6 +1,7 @@
 const fs = require('fs')
 const OutputFiles = require('./output-files')
 const mkdirp = require('mkdirp')
+const pathLib = require('path')
 const PuppeteerToV8 = require('./puppeteer-to-v8')
 const v8toIstanbul = require('v8-to-istanbul')
 
@@ -36,6 +37,13 @@ class PuppeteerToIstanbul {
 
       let istanbulCoverage = script.toIstanbul()
       let keys = Object.keys(istanbulCoverage)
+      const prefix = pathLib.resolve(this.storagePath, 'js')
+      const realPath = pathLib.resolve(pathLib.relative(prefix, keys[0]))
+
+      istanbulCoverage[realPath] = istanbulCoverage[keys[0]]
+      istanbulCoverage[realPath].path = realPath
+      delete istanbulCoverage[keys[0]]
+      keys[0] = realPath
 
       if (jsonPart[keys[0]]) {
         // Merge coverage records
@@ -45,6 +53,12 @@ class PuppeteerToIstanbul {
       }
       jsonPart[keys[0]].originalUrl = jsFile.originalUrl
     })
+
+    for (const foo in jsonPart) {
+      if (!fs.existsSync(foo)) {
+        delete jsonPart[foo]
+      }
+    }
 
     fs.writeSync(fd, '{')
     Object.keys(jsonPart).forEach((url, index, keys) => {

--- a/lib/puppeteer-to-istanbul.js
+++ b/lib/puppeteer-to-istanbul.js
@@ -49,12 +49,14 @@ class PuppeteerToIstanbul {
       // so we remove them.
       Object.entries(istanbulCoverage[jsFile.realPath].statementMap).forEach(entry => {
         if (entry[1].end.column <= 0) {
-          delete istanbulCoverage[jsFile.realPath].statementMap[entry[0]]
+          //delete istanbulCoverage[jsFile.realPath].statementMap[entry[0]]
+          entry[1].end.column = 1
         }
       })
       Object.entries(istanbulCoverage[jsFile.realPath].branchMap).forEach(entry => {
         if (entry[1].loc.end.column <= 0) {
-          delete istanbulCoverage[jsFile.realPath].branchMap[entry[0]]
+          //delete istanbulCoverage[jsFile.realPath].branchMap[entry[0]]
+          entry[1].loc.end.column = 1
         }
       })
 

--- a/lib/puppeteer-to-istanbul.js
+++ b/lib/puppeteer-to-istanbul.js
@@ -37,13 +37,26 @@ class PuppeteerToIstanbul {
 
       let istanbulCoverage = script.toIstanbul()
       let keys = Object.keys(istanbulCoverage)
-      const prefix = pathLib.resolve(this.storagePath, 'js')
-      const realPath = pathLib.resolve(pathLib.relative(prefix, keys[0]))
 
-      istanbulCoverage[realPath] = istanbulCoverage[keys[0]]
-      istanbulCoverage[realPath].path = realPath
+      istanbulCoverage[jsFile.realPath] = istanbulCoverage[keys[0]]
       delete istanbulCoverage[keys[0]]
-      keys[0] = realPath
+      keys[0] = jsFile.realPath
+      istanbulCoverage[jsFile.realPath].path = jsFile.realPath
+
+      // for some reason there are invalid column values in the
+      // statement and branch maps that lead to errors in the
+      // source-map package. end values cannot have column=0,
+      // so we remove them.
+      Object.entries(istanbulCoverage[jsFile.realPath].statementMap).forEach(entry => {
+        if (entry[1].end.column <= 0) {
+          delete istanbulCoverage[jsFile.realPath].statementMap[entry[0]]
+        }
+      })
+      Object.entries(istanbulCoverage[jsFile.realPath].branchMap).forEach(entry => {
+        if (entry[1].loc.end.column <= 0) {
+          delete istanbulCoverage[jsFile.realPath].branchMap[entry[0]]
+        }
+      })
 
       if (jsonPart[keys[0]]) {
         // Merge coverage records
@@ -52,6 +65,7 @@ class PuppeteerToIstanbul {
         jsonPart[keys[0]] = istanbulCoverage[keys[0]]
       }
       jsonPart[keys[0]].originalUrl = jsFile.originalUrl
+      jsonPart[keys[0]].inputSourceMap = jsFile.sourceMapping
     })
 
     for (const foo in jsonPart) {

--- a/lib/puppeteer-to-istanbul.js
+++ b/lib/puppeteer-to-istanbul.js
@@ -68,9 +68,9 @@ class PuppeteerToIstanbul {
       jsonPart[keys[0]].inputSourceMap = jsFile.sourceMapping
     })
 
-    for (const foo in jsonPart) {
-      if (!fs.existsSync(foo)) {
-        delete jsonPart[foo]
+    for (const path in jsonPart) {
+      if (!fs.existsSync(path)) {
+        delete jsonPart[path]
       }
     }
 

--- a/lib/puppeteer-to-v8.js
+++ b/lib/puppeteer-to-v8.js
@@ -16,6 +16,8 @@ class PuppeteerToV8 {
         scriptId: id++,
         url: 'file://' + coverageItem.url,
         originalUrl: coverageItem.originalUrl,
+        realPath: coverageItem.realPath,
+        sourceMapping: coverageItem.sourceMapping,
         functions: [{
           ranges: coverageItem.ranges.map(this.convertRange),
           isBlockCoverage: true


### PR DESCRIPTION
Hey folks,

I like this package and it solves a lot of my code coverage problems in frontend testing!

One problem with the current implementation is that the coverage is actually measured on different files than the original ones. This works rather fine when you only measure coverage over visited files. However, it leads to problems when you e.g. work with the `nyc --all` option and you want to be precise with the covered files.

While it is necessary to write the generated webpack files to disk for `v8-to-istanbul`, we actually do not need to pass the coverage data on as-is. We can convert them back to their original paths and have nice and consistent coverage data.

The current proposal is kinda the idea, there are failing tests and I need some feedback from contributors who are deeper into the topic. Also, the implementation with the for loops is a bit error prone, I'd prefer a non-mutating solution here.

Would love to have this integrated. For me it's working fine!